### PR TITLE
Simplify Binary API Read For Callers

### DIFF
--- a/binary_api.cpp
+++ b/binary_api.cpp
@@ -44,9 +44,9 @@ void BinaryAPI::write_file()
 
 void BinaryAPI::read_file()
 {
-    FileId id;
-    _input >> id;
-    _fs->read(id)
+    CharString filename;
+    _input >> filename;
+    _fs->read(filename)
         .match(
             [&](auto&& file) {
                 _output.put(static_cast<byte>(CommandStatus::OK));

--- a/file_system.h
+++ b/file_system.h
@@ -35,6 +35,7 @@ class FileSystem
         void free_inode(unsigned int address);
 
         either<FileId, FileSystemError> get_next_file_header(unsigned int starting_address);
+        either<FileId, FileSystemError> get_fileid_by_filename(const CharString& filename);
 
         File read_address_to_file(unsigned int address);
         CharString read_file_to_string(unsigned int address);
@@ -67,6 +68,7 @@ class FileSystem
         void format(const CharString& encryption_iv, const CharString& challenge);
         const FSMasterBlock& get_master_block() const;
         either<FileId, FileSystemError> write(const File& file);
+        either<File, FileSystemError> read(const CharString& filename);
         either<File, FileSystemError> read(const FileId& fileId);
         either<CharString, FileSystemError> get_filename(const FileId& fileId);
         either<unsigned int, FileSystemError> remove(const FileId& fileId);


### PR DESCRIPTION
Previously a caller was expected to get a list of all file ids and read
each one's filename individually to see if matched the filename they
were looking for. This has been improved to only ask the caller to
encrypt the filename first, send it to the device and the device will
return the appropriate file after finding it by name.